### PR TITLE
feat: switch from stdlib log to log/slog for structured failure logging

### DIFF
--- a/ach/create.go
+++ b/ach/create.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 
 	"github.com/Lendiom/go-payarc"
@@ -40,17 +40,29 @@ func (s *Service) Create(input CreateAchChargeInput) (*ACHChargeResult, error) {
 	r.Body = io.NopCloser(bytes.NewReader(body))
 
 	if r.StatusCode > http.StatusIMUsed || r.StatusCode < http.StatusOK {
-		log.Println("Payload for ach charge creation is:")
-		log.Println(string(data))
-		log.Println("Failed to create a charge. Result is:")
-		log.Println(string(body))
-
 		var errMsg payarc.RequestError
 		if err := json.NewDecoder(r.Body).Decode(&errMsg); err != nil {
+			slog.Error("payarc ach charge create failed; response body did not parse",
+				slog.String("component", "go-payarc"),
+				slog.String("op", "ach.create"),
+				slog.Int("status_code", r.StatusCode),
+				slog.String("payload", string(data)),
+				slog.String("body", string(body)),
+				slog.Any("error", err),
+			)
 			return nil, err
 		}
 
-		log.Printf("Failed to create the charge: %+v", errMsg)
+		slog.Error("payarc ach charge create failed",
+			slog.String("component", "go-payarc"),
+			slog.String("op", "ach.create"),
+			slog.Int("status_code", r.StatusCode),
+			slog.String("payload", string(data)),
+			slog.String("body", string(body)),
+			slog.String("payarc_message", errMsg.Message),
+			slog.String("payarc_error", errMsg.Error),
+			slog.Any("payarc_field_errors", errMsg.Errors),
+		)
 
 		switch errMsg.Message {
 		case "Unauthorized SEC type":
@@ -62,8 +74,12 @@ func (s *Service) Create(input CreateAchChargeInput) (*ACHChargeResult, error) {
 
 	var res CreateACHChargeResponse
 	if err := json.NewDecoder(r.Body).Decode(&res); err != nil {
-		log.Println("failed to decode response body. the response was:")
-		log.Println(string(body))
+		slog.Error("payarc ach charge create succeeded; response body did not parse",
+			slog.String("component", "go-payarc"),
+			slog.String("op", "ach.create"),
+			slog.String("body", string(body)),
+			slog.Any("error", err),
+		)
 
 		return nil, err
 	}

--- a/ach/get.go
+++ b/ach/get.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 
 	"github.com/Lendiom/go-payarc"
@@ -57,17 +57,31 @@ func (s *Service) GetByID(id string) (*payarc.ACHCharge, error) {
 			return nil, err
 		}
 
-		log.Println("Failed to get a charge. Result is:")
-		log.Println(string(body))
-
 		r.Body = io.NopCloser(bytes.NewReader(body))
 
 		var errMsg payarc.RequestError
 		if err := json.NewDecoder(r.Body).Decode(&errMsg); err != nil {
+			slog.Error("payarc ach charge get failed; response body did not parse",
+				slog.String("component", "go-payarc"),
+				slog.String("op", "ach.get_by_id"),
+				slog.String("charge_id", id),
+				slog.Int("status_code", r.StatusCode),
+				slog.String("body", string(body)),
+				slog.Any("error", err),
+			)
 			return nil, err
 		}
 
-		log.Printf("Failed to get the charge: %+v", errMsg)
+		slog.Error("payarc ach charge get failed",
+			slog.String("component", "go-payarc"),
+			slog.String("op", "ach.get_by_id"),
+			slog.String("charge_id", id),
+			slog.Int("status_code", r.StatusCode),
+			slog.String("body", string(body)),
+			slog.String("payarc_message", errMsg.Message),
+			slog.String("payarc_error", errMsg.Error),
+			slog.Any("payarc_field_errors", errMsg.Errors),
+		)
 
 		if errMsg.Error != "" {
 			return nil, fmt.Errorf("failed to get the charge: %s", errMsg.Error)

--- a/banks/create.go
+++ b/banks/create.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -42,15 +42,28 @@ func (s *Service) Create(input CreateBankAccountInput) (*payarc.BankAccountCreat
 	r.Body = io.NopCloser(bytes.NewReader(body))
 
 	if r.StatusCode > http.StatusIMUsed || r.StatusCode < http.StatusOK {
-		log.Println("Failed to create a bank account. Result is:")
-		log.Println(string(body))
-
 		var errMsg payarc.RequestError
 		if err := json.NewDecoder(r.Body).Decode(&errMsg); err != nil {
+			slog.Error("payarc bank account create failed; response body did not parse",
+				slog.String("component", "go-payarc"),
+				slog.String("op", "banks.create"),
+				slog.Int("status_code", r.StatusCode),
+				slog.String("body", string(body)),
+				slog.Any("error", err),
+			)
 			return nil, err
 		}
 
-		log.Printf("Failed to create the bank account: %+v", errMsg)
+		slog.Error("payarc bank account create failed",
+			slog.String("component", "go-payarc"),
+			slog.String("op", "banks.create"),
+			slog.Int("status_code", r.StatusCode),
+			slog.String("body", string(body)),
+			slog.String("payarc_message", errMsg.Message),
+			slog.String("payarc_error", errMsg.Error),
+			slog.Any("payarc_field_errors", errMsg.Errors),
+		)
+
 		msg := errMsg.Message
 		if errMsg.Error != "" {
 			msg = errMsg.Error
@@ -61,8 +74,12 @@ func (s *Service) Create(input CreateBankAccountInput) (*payarc.BankAccountCreat
 
 	var res payarc.BankAccountCreatedResponse
 	if err := json.NewDecoder(r.Body).Decode(&res); err != nil {
-		log.Println("Failed to decode the bank account create response:", err.Error())
-		log.Println(string(body))
+		slog.Error("payarc bank account create succeeded; response body did not parse",
+			slog.String("component", "go-payarc"),
+			slog.String("op", "banks.create"),
+			slog.String("body", string(body)),
+			slog.Any("error", err),
+		)
 
 		return nil, err
 	}

--- a/charges/create.go
+++ b/charges/create.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -40,17 +40,29 @@ func (s *Service) Create(input ChargeInput) (*ChargeResult, error) {
 			return nil, err
 		}
 
-		log.Println("Failed to create a charge. Result is:")
-		log.Println(string(body))
-
 		r.Body = io.NopCloser(bytes.NewReader(body))
 
 		var errMsg payarc.RequestError
 		if err := json.NewDecoder(r.Body).Decode(&errMsg); err != nil {
+			slog.Error("payarc charge create failed; response body did not parse",
+				slog.String("component", "go-payarc"),
+				slog.String("op", "charges.create"),
+				slog.Int("status_code", r.StatusCode),
+				slog.String("body", string(body)),
+				slog.Any("error", err),
+			)
 			return nil, err
 		}
 
-		log.Printf("Failed to create the charge: %+v", errMsg)
+		slog.Error("payarc charge create failed",
+			slog.String("component", "go-payarc"),
+			slog.String("op", "charges.create"),
+			slog.Int("status_code", r.StatusCode),
+			slog.String("body", string(body)),
+			slog.String("payarc_message", errMsg.Message),
+			slog.String("payarc_error", errMsg.Error),
+			slog.Any("payarc_field_errors", errMsg.Errors),
+		)
 
 		switch strings.ToLower(errMsg.Message) {
 		case "invalid card":

--- a/charges/refund.go
+++ b/charges/refund.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -48,17 +48,31 @@ func (s *Service) Void(chargeID string, input VoidInput) (*payarc.Charge, error)
 			return nil, err
 		}
 
-		log.Println("Failed to void a charge. Result is:")
-		log.Println(string(body))
-
 		r.Body = io.NopCloser(bytes.NewReader(body))
 
 		var errMsg payarc.RequestError
 		if err := json.NewDecoder(r.Body).Decode(&errMsg); err != nil {
+			slog.Error("payarc charge void failed; response body did not parse",
+				slog.String("component", "go-payarc"),
+				slog.String("op", "charges.void"),
+				slog.String("charge_id", chargeID),
+				slog.Int("status_code", r.StatusCode),
+				slog.String("body", string(body)),
+				slog.Any("error", err),
+			)
 			return nil, err
 		}
 
-		log.Printf("Failed to void the charge: %+v", errMsg)
+		slog.Error("payarc charge void failed",
+			slog.String("component", "go-payarc"),
+			slog.String("op", "charges.void"),
+			slog.String("charge_id", chargeID),
+			slog.Int("status_code", r.StatusCode),
+			slog.String("body", string(body)),
+			slog.String("payarc_message", errMsg.Message),
+			slog.String("payarc_error", errMsg.Error),
+			slog.Any("payarc_field_errors", errMsg.Errors),
+		)
 
 		return nil, fmt.Errorf("void charge failed: %s", errMsg.Message)
 	}
@@ -109,17 +123,31 @@ func (s *Service) Refund(chargeID string, input RefundInput) (*payarc.Refund, er
 			return nil, err
 		}
 
-		log.Println("Failed to create a refund. Result is:")
-		log.Println(string(body))
-
 		r.Body = io.NopCloser(bytes.NewReader(body))
 
 		var errMsg payarc.RequestError
 		if err := json.NewDecoder(r.Body).Decode(&errMsg); err != nil {
+			slog.Error("payarc charge refund failed; response body did not parse",
+				slog.String("component", "go-payarc"),
+				slog.String("op", "charges.refund"),
+				slog.String("charge_id", chargeID),
+				slog.Int("status_code", r.StatusCode),
+				slog.String("body", string(body)),
+				slog.Any("error", err),
+			)
 			return nil, err
 		}
 
-		log.Printf("Failed to refund the charge: %+v", errMsg)
+		slog.Error("payarc charge refund failed",
+			slog.String("component", "go-payarc"),
+			slog.String("op", "charges.refund"),
+			slog.String("charge_id", chargeID),
+			slog.Int("status_code", r.StatusCode),
+			slog.String("body", string(body)),
+			slog.String("payarc_message", errMsg.Message),
+			slog.String("payarc_error", errMsg.Error),
+			slog.Any("payarc_field_errors", errMsg.Errors),
+		)
 
 		return nil, fmt.Errorf("refund charge failed: %s", errMsg.Message)
 	}

--- a/customers/create.go
+++ b/customers/create.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -48,15 +48,29 @@ func (s *Service) Create(input CustomerInput) (*payarc.Customer, error) {
 			return nil, err
 		}
 
-		log.Println("Failed to create a customer. Result is:")
-		log.Println(string(body))
-
 		res.Body = io.NopCloser(bytes.NewReader(body))
 
 		var errMsg payarc.RequestError
 		if err := json.NewDecoder(res.Body).Decode(&errMsg); err != nil {
+			slog.Error("payarc customer create failed; response body did not parse",
+				slog.String("component", "go-payarc"),
+				slog.String("op", "customers.create"),
+				slog.Int("status_code", res.StatusCode),
+				slog.String("body", string(body)),
+				slog.Any("error", err),
+			)
 			return nil, err
 		}
+
+		slog.Error("payarc customer create failed",
+			slog.String("component", "go-payarc"),
+			slog.String("op", "customers.create"),
+			slog.Int("status_code", res.StatusCode),
+			slog.String("body", string(body)),
+			slog.String("payarc_message", errMsg.Message),
+			slog.String("payarc_error", errMsg.Error),
+			slog.Any("payarc_field_errors", errMsg.Errors),
+		)
 
 		return nil, fmt.Errorf("create customer failed: %s OR %s", errMsg.Message, errMsg.Error)
 	}
@@ -101,15 +115,31 @@ func (s *Service) CreateCard(id string, input TokenInput) (*payarc.Customer, *pa
 			return nil, nil, err
 		}
 
-		log.Println("Failed to create a card. Result is:")
-		log.Println(string(body))
-
 		res.Body = io.NopCloser(bytes.NewReader(body))
 
 		var errMsg payarc.RequestError
 		if err := json.NewDecoder(res.Body).Decode(&errMsg); err != nil {
+			slog.Error("payarc customer card create failed; response body did not parse",
+				slog.String("component", "go-payarc"),
+				slog.String("op", "customers.create_card"),
+				slog.String("customer_id", id),
+				slog.Int("status_code", res.StatusCode),
+				slog.String("body", string(body)),
+				slog.Any("error", err),
+			)
 			return nil, nil, err
 		}
+
+		slog.Error("payarc customer card create failed",
+			slog.String("component", "go-payarc"),
+			slog.String("op", "customers.create_card"),
+			slog.String("customer_id", id),
+			slog.Int("status_code", res.StatusCode),
+			slog.String("body", string(body)),
+			slog.String("payarc_message", errMsg.Message),
+			slog.String("payarc_error", errMsg.Error),
+			slog.Any("payarc_field_errors", errMsg.Errors),
+		)
 
 		return nil, nil, fmt.Errorf("create card failed: %s", errMsg.Message)
 	}
@@ -168,15 +198,29 @@ func (s *Service) createToken(input TokenInput) (*Token, error) {
 			return nil, err
 		}
 
-		log.Println("Failed to create a token. Result is:")
-		log.Println(string(body))
-
 		res.Body = io.NopCloser(bytes.NewReader(body))
 
 		var errMsg payarc.RequestError
 		if err := json.NewDecoder(res.Body).Decode(&errMsg); err != nil {
+			slog.Error("payarc token create failed; response body did not parse",
+				slog.String("component", "go-payarc"),
+				slog.String("op", "customers.create_token"),
+				slog.Int("status_code", res.StatusCode),
+				slog.String("body", string(body)),
+				slog.Any("error", err),
+			)
 			return nil, err
 		}
+
+		slog.Error("payarc token create failed",
+			slog.String("component", "go-payarc"),
+			slog.String("op", "customers.create_token"),
+			slog.Int("status_code", res.StatusCode),
+			slog.String("body", string(body)),
+			slog.String("payarc_message", errMsg.Message),
+			slog.String("payarc_error", errMsg.Error),
+			slog.Any("payarc_field_errors", errMsg.Errors),
+		)
 
 		switch strings.ToLower(errMsg.Message) {
 		case "invalid card":


### PR DESCRIPTION
## Summary

- Replace 2-3 unstructured \`log.Println\` / \`log.Printf\` calls per failed PayArc API response with a single \`slog.Error\` event carrying structured attributes (\`component\`, \`op\`, \`status_code\`, \`body\`, \`payarc_message\`, \`payarc_error\`, \`payarc_field_errors\`).
- Public API (function signatures, return types, sentinel errors) is unchanged — only logging behavior is affected.
- No level-flip masquerading: failed PayArc calls still log at error severity; the gain is structure, not silence.

## Why

Consumers that call \`slog.SetDefault\` (e.g. landpro-server) automatically capture stdlib \`log\` output through the slog bridge as INFO, producing 2-3 separate JSON entries per failed charge with the response body — including PII like \`customer_email\` — sitting in the free-text \`msg\` field. That makes Loki/Grafana filtering brittle (\"grep msg\") and prevents structured redaction.

After this change a failed charge produces one event whose attributes are filterable directly in LogQL, and the consumer can apply slog \`ReplaceAttr\` rules (e.g. masq) to the body field rather than trying to redact the whole message.

## Affected operations

- \`ach.create\`, \`ach.get_by_id\`
- \`banks.create\`
- \`charges.create\`, \`charges.void\`, \`charges.refund\`
- \`customers.create\`, \`customers.create_card\`, \`customers.create_token\`

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./...\` passes (only existing util tests)
- [x] \`gofmt -l\` clean on all changed files
- [x] No \`\"log\"\` import remains in non-test source

🤖 Generated with [Claude Code](https://claude.com/claude-code)