### PR TITLE
fix(ach): add CompanyName to CreateAchChargeInput

### DIFF
--- a/ach/input.go
+++ b/ach/input.go
@@ -29,6 +29,7 @@ type CreateAchChargeInput struct {
 	RoutingNumber string `json:"routing_number,omitempty"` //RoutingNumber is required if the CustomerID is not provided
 	FirstName     string `json:"first_name,omitempty"`     //FirstName is required if the CustomerID is not provided
 	LastName      string `json:"last_name,omitempty"`      //LastName is required if the CustomerID is not provided
+	CompanyName   string `json:"company_name,omitempty"`   //CompanyName is required when AccountType is "Business Checking" or "Business Savings"
 	ReceiptEmail  string `json:"receipt_email,omitempty"`  //ReceiptEmail is optional
 	ReceiptPhone  string `json:"receipt_phone,omitempty"`  //ReceiptPhone is optional
 	AddressLine1  string `json:"address_line1,omitempty"`  //AddressLine1 is optional

--- a/ach/input_test.go
+++ b/ach/input_test.go
@@ -1,0 +1,67 @@
+package ach
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Lendiom/go-payarc"
+)
+
+func TestCreateAchChargeInput_JSONIncludesCompanyName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    CreateAchChargeInput
+		contains []string
+		omits    []string
+	}{
+		{
+			name: "Business Checking includes company_name",
+			input: CreateAchChargeInput{
+				CustomerID:    "cust_1",
+				BankAccountID: "bank_1",
+				AccountType:   payarc.ACHAccountTypeBusinessChecking,
+				Currency:      payarc.CurrencyUSD,
+				Amount:        12345,
+				Type:          payarc.ACHFlowTypeDebit,
+				SecCode:       AchCreateChargeSecCodeCorporateCashDisbursement,
+				CompanyName:   "ACME Corp",
+			},
+			contains: []string{`"company_name":"ACME Corp"`, `"account_type":"Business Checking"`},
+		},
+		{
+			name: "Personal Checking omits company_name when empty",
+			input: CreateAchChargeInput{
+				CustomerID:    "cust_1",
+				BankAccountID: "bank_1",
+				AccountType:   payarc.ACHAccountTypePersonalChecking,
+				Currency:      payarc.CurrencyUSD,
+				Amount:        12345,
+				Type:          payarc.ACHFlowTypeDebit,
+				SecCode:       AchCreateChargeSecCodeWeb,
+			},
+			omits: []string{`"company_name"`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.input)
+			if err != nil {
+				t.Fatalf("Marshal() error = %v", err)
+			}
+
+			out := string(data)
+			for _, want := range tt.contains {
+				if !strings.Contains(out, want) {
+					t.Errorf("Marshal() = %s; expected to contain %s", out, want)
+				}
+			}
+			for _, omit := range tt.omits {
+				if strings.Contains(out, omit) {
+					t.Errorf("Marshal() = %s; expected NOT to contain %s", out, omit)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- PayArc started returning `422 The company name field is required when account type is Business Checking.` on ACH charge create for Business Checking / Business Savings accounts, even though the company name is set on the bank account itself.
- This adds an optional `CompanyName string` to `CreateAchChargeInput` (omitempty), serialized as `company_name`, so callers can pass it on the charge request.

## Evidence
Loki errors in lendiom-production (last 24h) — 4 consecutive failures for the same Business Checking customer:
```
op=ach.create status_code=422
payload={"customer_id":"...","bank_account_id":"...","account_type":"Business Checking","currency":"usd","amount":139478,"type":"debit","sec_code":"CCD"}
body={"message":"The given data was invalid.","errors":{"company_name":["The company name field is required when account type is Business Checking."]}}
```

## Test plan
- [x] `go test ./...` passes
- [x] New `TestCreateAchChargeInput_JSONIncludesCompanyName` verifies `company_name` is serialized when populated and omitted when empty
- [ ] Tag a new release after merge so `landpro-server` can bump and pass `CompanyName` for business accounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)