### PR TITLE
fix(charges): log known business declines at WARN, not ERROR

### DIFF
--- a/charges/create.go
+++ b/charges/create.go
@@ -54,7 +54,13 @@ func (s *Service) Create(input ChargeInput) (*ChargeResult, error) {
 			return nil, err
 		}
 
-		slog.Error("payarc charge create failed",
+		// Business declines (insufficient funds, expired card, do-not-honor,
+		// etc.) are the expected outcome of attempting a payment, not server
+		// failures — log them at WARN so they stop polluting ERROR dashboards
+		// and on-call channels. Anything we don't recognize stays at ERROR.
+		sentinel, declined := payarc.ClassifyChargeDecline(errMsg.Message)
+
+		attrs := []any{
 			slog.String("component", "go-payarc"),
 			slog.String("op", "charges.create"),
 			slog.Int("status_code", r.StatusCode),
@@ -62,32 +68,14 @@ func (s *Service) Create(input ChargeInput) (*ChargeResult, error) {
 			slog.String("payarc_message", errMsg.Message),
 			slog.String("payarc_error", errMsg.Error),
 			slog.Any("payarc_field_errors", errMsg.Errors),
-		)
-
-		switch strings.ToLower(errMsg.Message) {
-		case "invalid card":
-			return nil, payarc.ErrInvalidCard
-		case "insufficient funds":
-			return nil, payarc.ErrInsufficientFunds
-		case "suspected fraud":
-			return nil, payarc.ErrSuspectedFraud
-		case "do not honor":
-			return nil, payarc.ErrDoNotHonor
-		case "suspected card":
-			return nil, payarc.ErrSuspectedCard
-		case "invalid from account":
-			return nil, payarc.ErrInvalidFromAccount
-		case "withdrawal limit exceeded":
-			return nil, payarc.ErrWithdrawalLimitExceeded
-		case "customer requested stop of all recurring payments from specific merchant":
-			return nil, payarc.ErrCustomerRequestedStopPayments
-		case "expired card":
-			return nil, payarc.ErrExpiredCard
-		case "general cardauth decline":
-			return nil, payarc.ErrGeneralCardAuthDecline
-		case "closed account":
-			return nil, payarc.ErrClosedAccount
 		}
+
+		if declined {
+			slog.Warn("payarc declined charge", attrs...)
+			return nil, sentinel
+		}
+
+		slog.Error("payarc charge create failed", attrs...)
 
 		return nil, fmt.Errorf("create charge failed: %s", errMsg.Message)
 	}

--- a/charges/create_test.go
+++ b/charges/create_test.go
@@ -1,0 +1,140 @@
+package charges
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/Lendiom/go-payarc"
+	"github.com/Lendiom/go-payarc/client"
+)
+
+// levelRecorder is a slog.Handler that captures the level and message of
+// every record routed through it. It exists so tests can assert the
+// classification chose WARN vs ERROR without inspecting log output buffers.
+type levelRecorder struct {
+	records []slog.Record
+}
+
+func (lr *levelRecorder) Enabled(_ context.Context, _ slog.Level) bool { return true }
+func (lr *levelRecorder) Handle(_ context.Context, r slog.Record) error {
+	lr.records = append(lr.records, r)
+	return nil
+}
+func (lr *levelRecorder) WithAttrs([]slog.Attr) slog.Handler { return lr }
+func (lr *levelRecorder) WithGroup(string) slog.Handler      { return lr }
+
+func newServiceForTest(t *testing.T, statusCode int, body string) (*Service, func()) {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		_, _ = w.Write([]byte(body))
+	}))
+
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse httptest URL: %v", err)
+	}
+
+	svc := &Service{
+		client: client.Client{
+			ApiKey:     "test-key",
+			HttpClient: *srv.Client(),
+			Url:        *u,
+		},
+	}
+
+	return svc, srv.Close
+}
+
+func TestCreate_BusinessDeclineLogsAtWarnAndReturnsSentinel(t *testing.T) {
+	tests := []struct {
+		name        string
+		statusCode  int
+		body        string
+		wantErr     error
+		wantLogLvl  slog.Level
+		wantLogMsg  string
+	}{
+		{
+			name:       "Insufficient Funds → WARN + ErrInsufficientFunds",
+			statusCode: http.StatusUnprocessableEntity,
+			body:       `{"status":"error","code":0,"message":"Insufficient Funds","status_code":422,"data":{}}`,
+			wantErr:    payarc.ErrInsufficientFunds,
+			wantLogLvl: slog.LevelWarn,
+			wantLogMsg: "payarc declined charge",
+		},
+		{
+			name:       "Expired Card → WARN + ErrExpiredCard",
+			statusCode: http.StatusUnprocessableEntity,
+			body:       `{"status":"error","message":"Expired Card","status_code":422}`,
+			wantErr:    payarc.ErrExpiredCard,
+			wantLogLvl: slog.LevelWarn,
+			wantLogMsg: "payarc declined charge",
+		},
+		{
+			name:       "Do Not Honor → WARN + ErrDoNotHonor",
+			statusCode: http.StatusUnprocessableEntity,
+			body:       `{"status":"error","message":"Do Not Honor","status_code":422}`,
+			wantErr:    payarc.ErrDoNotHonor,
+			wantLogLvl: slog.LevelWarn,
+			wantLogMsg: "payarc declined charge",
+		},
+		{
+			name:       "Unknown message → ERROR (alerting path stays intact)",
+			statusCode: http.StatusInternalServerError,
+			body:       `{"status":"error","message":"Some New Failure Mode","status_code":500}`,
+			wantErr:    nil, // wrapped fmt.Errorf, not a sentinel
+			wantLogLvl: slog.LevelError,
+			wantLogMsg: "payarc charge create failed",
+		},
+		{
+			name:       "Unparseable body → ERROR (the parse-failure log line)",
+			statusCode: http.StatusBadGateway,
+			body:       `<html>upstream down</html>`,
+			wantErr:    nil,
+			wantLogLvl: slog.LevelError,
+			wantLogMsg: "payarc charge create failed; response body did not parse",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, cleanup := newServiceForTest(t, tt.statusCode, tt.body)
+			defer cleanup()
+
+			recorder := &levelRecorder{}
+			origLogger := slog.Default()
+			slog.SetDefault(slog.New(recorder))
+			defer slog.SetDefault(origLogger)
+
+			_, err := svc.Create(ChargeInput{Amount: 100, CustomerID: "cust_1"})
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+
+			if tt.wantErr != nil && !errors.Is(err, tt.wantErr) {
+				t.Errorf("err = %v, want sentinel %v", err, tt.wantErr)
+			}
+
+			if len(recorder.records) != 1 {
+				t.Fatalf("expected exactly 1 log record, got %d", len(recorder.records))
+			}
+
+			rec := recorder.records[0]
+			if rec.Level != tt.wantLogLvl {
+				t.Errorf("log level = %v, want %v (msg=%q)", rec.Level, tt.wantLogLvl, rec.Message)
+			}
+
+			if rec.Message != tt.wantLogMsg {
+				t.Errorf("log message = %q, want %q", rec.Message, tt.wantLogMsg)
+			}
+		})
+	}
+}

--- a/errors.go
+++ b/errors.go
@@ -1,6 +1,9 @@
 package payarc
 
-import "errors"
+import (
+	"errors"
+	"strings"
+)
 
 var (
 	ErrInsufficientFunds             = errors.New("insufficient funds, charge failed")
@@ -26,4 +29,44 @@ type RequestError struct {
 	Message string             `json:"message"`
 	Error   string             `json:"error"`
 	Errors  RequestErrorErrors `json:"errors,omitempty"`
+}
+
+// ClassifyChargeDecline maps a known PayArc charge-decline message to its
+// sentinel error. It returns (sentinel, true) when the message is a
+// recognized business decline the cardholder/bank owns (insufficient funds,
+// expired card, do-not-honor, etc.) and (nil, false) otherwise.
+//
+// Callers use the boolean to decide log level: business declines are expected
+// outcomes of attempting a payment and should be logged at WARN, while
+// unknown messages, parse failures, and server-side errors should keep
+// ERROR-level logging so they still surface in alerting dashboards.
+//
+// Matching is case-insensitive against the PayArc `message` field.
+func ClassifyChargeDecline(message string) (error, bool) {
+	switch strings.ToLower(message) {
+	case "invalid card":
+		return ErrInvalidCard, true
+	case "insufficient funds":
+		return ErrInsufficientFunds, true
+	case "suspected fraud":
+		return ErrSuspectedFraud, true
+	case "do not honor":
+		return ErrDoNotHonor, true
+	case "suspected card":
+		return ErrSuspectedCard, true
+	case "invalid from account":
+		return ErrInvalidFromAccount, true
+	case "withdrawal limit exceeded":
+		return ErrWithdrawalLimitExceeded, true
+	case "customer requested stop of all recurring payments from specific merchant":
+		return ErrCustomerRequestedStopPayments, true
+	case "expired card":
+		return ErrExpiredCard, true
+	case "general cardauth decline":
+		return ErrGeneralCardAuthDecline, true
+	case "closed account":
+		return ErrClosedAccount, true
+	}
+
+	return nil, false
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,90 @@
+package payarc
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestClassifyChargeDecline(t *testing.T) {
+	tests := []struct {
+		name        string
+		message     string
+		wantErr     error
+		wantMatched bool
+	}{
+		{
+			name:        "Insufficient Funds (canonical casing)",
+			message:     "Insufficient Funds",
+			wantErr:     ErrInsufficientFunds,
+			wantMatched: true,
+		},
+		{
+			name:        "insufficient funds (lowercase) still matches",
+			message:     "insufficient funds",
+			wantErr:     ErrInsufficientFunds,
+			wantMatched: true,
+		},
+		{
+			name:        "INSUFFICIENT FUNDS (uppercase) still matches",
+			message:     "INSUFFICIENT FUNDS",
+			wantErr:     ErrInsufficientFunds,
+			wantMatched: true,
+		},
+		{
+			name:        "Expired Card",
+			message:     "Expired Card",
+			wantErr:     ErrExpiredCard,
+			wantMatched: true,
+		},
+		{
+			name:        "Do Not Honor",
+			message:     "Do Not Honor",
+			wantErr:     ErrDoNotHonor,
+			wantMatched: true,
+		},
+		{
+			name:        "Closed Account",
+			message:     "Closed Account",
+			wantErr:     ErrClosedAccount,
+			wantMatched: true,
+		},
+		{
+			name:        "Customer Requested Stop (long message verbatim)",
+			message:     "Customer Requested Stop of All Recurring Payments from Specific Merchant",
+			wantErr:     ErrCustomerRequestedStopPayments,
+			wantMatched: true,
+		},
+		{
+			name:        "General CardAuth Decline",
+			message:     "General CardAuth Decline",
+			wantErr:     ErrGeneralCardAuthDecline,
+			wantMatched: true,
+		},
+		{
+			name:        "Unknown message does not match (must stay at ERROR)",
+			message:     "Some new failure mode PayArc invented",
+			wantErr:     nil,
+			wantMatched: false,
+		},
+		{
+			name:        "Empty message does not match",
+			message:     "",
+			wantErr:     nil,
+			wantMatched: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotErr, gotMatched := ClassifyChargeDecline(tt.message)
+
+			if gotMatched != tt.wantMatched {
+				t.Errorf("matched = %v, want %v", gotMatched, tt.wantMatched)
+			}
+
+			if !errors.Is(gotErr, tt.wantErr) {
+				t.Errorf("err = %v, want %v", gotErr, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Every PayArc 4xx with a known decline message (`Insufficient Funds`, `Expired Card`, `Do Not Honor`, `Closed Account`, etc.) was being logged at `slog.LevelError`. Those are the expected outcome of attempting a payment against a card the bank declined — not server failures — and they have been polluting the consumer app's ERROR dashboard for every declined transaction. Most recently surfaced in the 2026-05-16 `lendiom-api` Grafana review, where two "Insufficient Funds" declines for one customer showed up as ERROR-level entries.

This PR pulls the existing `switch errMsg.Message { ... }` block out into a reusable classifier (`payarc.ClassifyChargeDecline`) so we can branch on it for log level. The classifier is also case-insensitive now, matching the original behavior in `charges/create.go`.

**Behavior change:**

| Condition | Before | After |
|---|---|---|
| Known decline message (Insufficient Funds, etc.) | ERROR `"payarc charge create failed"` | WARN `"payarc declined charge"` |
| Unknown message / unexpected status | ERROR `"payarc charge create failed"` | unchanged |
| Body did not parse | ERROR `"payarc charge create failed; response body did not parse"` | unchanged |
| Returned sentinel error (`ErrInsufficientFunds`, etc.) | same | same |

Structured attribute set is unchanged (`component`, `op`, `status_code`, `body`, `payarc_message`, `payarc_error`, `payarc_field_errors`), so existing Loki queries that filter on those still work — only `level` and the human-readable `msg` shift for decline cases. Unknown messages still ERROR so a new failure mode invented by PayArc cannot silently drop off the alerting path.

## Test plan
- [x] `go test ./...` — new tests pass, existing tests still pass.
- [x] `TestClassifyChargeDecline` — every known message variant (canonical, lowercase, uppercase) maps to the correct sentinel; unknown / empty messages do not match.
- [x] `TestCreate_BusinessDeclineLogsAtWarnAndReturnsSentinel` — drives the real `Create` via an `httptest` server, swaps `slog.Default()` with a recording handler, asserts both the level (`Warn` vs `Error`) and the exact log message string for each branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)