### PR TITLE
feat(errors): classify "Refer to Issuer" as a known business decline

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -21,6 +21,7 @@ var (
 	ErrWithdrawalLimitExceeded       = errors.New("withdrawal limit exceeded")
 	ErrCustomerRequestedStopPayments = errors.New("customer requested stop payments for this seller")
 	ErrClosedAccount                 = errors.New("account is closed")
+	ErrReferToIssuer                 = errors.New("issuing bank declined and asked the cardholder to contact them")
 )
 
 type RequestErrorErrors map[string][]string
@@ -66,6 +67,15 @@ func ClassifyChargeDecline(message string) (error, bool) {
 		return ErrGeneralCardAuthDecline, true
 	case "closed account":
 		return ErrClosedAccount, true
+	case "refer to issuer":
+		// Standard ISO 8583 decline surfaced by PayArc from host response
+		// codes like D2001 ("Refer to card issuers special conditions").
+		// The issuing bank declined and wants the cardholder to contact
+		// them — there is nothing the merchant or processor can do to make
+		// the charge succeed. Functionally close to ErrDoNotHonor but a
+		// distinct host code, so keep it as its own sentinel so callers
+		// can surface a tailored "contact your card issuer" message.
+		return ErrReferToIssuer, true
 	}
 
 	return nil, false

--- a/errors_test.go
+++ b/errors_test.go
@@ -61,6 +61,18 @@ func TestClassifyChargeDecline(t *testing.T) {
 			wantMatched: true,
 		},
 		{
+			name:        "Refer to Issuer (canonical casing)",
+			message:     "Refer to Issuer",
+			wantErr:     ErrReferToIssuer,
+			wantMatched: true,
+		},
+		{
+			name:        "refer to issuer (lowercase) still matches",
+			message:     "refer to issuer",
+			wantErr:     ErrReferToIssuer,
+			wantMatched: true,
+		},
+		{
 			name:        "Unknown message does not match (must stay at ERROR)",
 			message:     "Some new failure mode PayArc invented",
 			wantErr:     nil,


### PR DESCRIPTION
## Summary

- PayArc returns ` "Refer to Issuer" ` (surfaced from host response codes like D2001 — "Refer to card issuers special conditions") on charge attempts where the issuing bank declined and is asking the cardholder to contact them. This is a standard ISO 8583 business decline owned by the cardholder/bank, not a server-side failure.
- `ClassifyChargeDecline` previously did not recognize this message, so `charges.Create` logged it at ERROR via the unmapped fall-through and returned a generic string error to the caller. That triggered ERROR-level noise in production for an expected business outcome and gave downstream consumers no typed sentinel to branch on.
- Add `ErrReferToIssuer` and a matching `case "refer to issuer"` in `ClassifyChargeDecline` so the lib logs at WARN per its own contract, and callers (e.g. landpro-server) can branch on the typed error to surface a tailored "contact your card issuer" message.
- Functionally close to `ErrDoNotHonor` but a distinct host code — kept as its own sentinel so callers can distinguish.

## Test plan

- [x] `go test ./...` — passes
- [x] `go vet ./...` — clean
- [x] `gofmt -l` clean on changed files
- [x] New `TestClassifyChargeDecline` cases cover canonical-cased and lowercase "Refer to Issuer".

## Downstream

- Companion PR in landpro-server is [FideTech/landpro-server#751](https://github.com/FideTech/landpro-server/pull/751), which already handles `"Refer to Issuer"` via the `strings.Contains` fallback pattern. Once this lib change ships in a tagged release, that downstream code can be tightened to `errors.Is(err, payarc.ErrReferToIssuer)` matching the other typed branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)