### PR TITLE
fix(payarc): WARN on known token declines + classify "Re-enter transaction"

### DIFF
--- a/charges/create_test.go
+++ b/charges/create_test.go
@@ -87,6 +87,14 @@ func TestCreate_BusinessDeclineLogsAtWarnAndReturnsSentinel(t *testing.T) {
 			wantLogMsg: "payarc declined charge",
 		},
 		{
+			name:       "Re-enter transaction → WARN + ErrReEnterTransaction",
+			statusCode: http.StatusUnprocessableEntity,
+			body:       `{"status":"error","message":"Re-enter transaction","status_code":422,"data":{"failure_code":"D0092","host_response_code":"19"}}`,
+			wantErr:    payarc.ErrReEnterTransaction,
+			wantLogLvl: slog.LevelWarn,
+			wantLogMsg: "payarc declined charge",
+		},
+		{
 			name:       "Unknown message → ERROR (alerting path stays intact)",
 			statusCode: http.StatusInternalServerError,
 			body:       `{"status":"error","message":"Some New Failure Mode","status_code":500}`,

--- a/customers/create.go
+++ b/customers/create.go
@@ -212,7 +212,14 @@ func (s *Service) createToken(input TokenInput) (*Token, error) {
 			return nil, err
 		}
 
-		slog.Error("payarc token create failed",
+		// Business declines (do-not-honor, CVV2 failure, suspected fraud,
+		// etc.) are the expected outcome of attempting to tokenize a card,
+		// not server failures — log them at WARN so they stop polluting
+		// ERROR dashboards and on-call channels. Mirrors the WARN/ERROR
+		// split already in place for charges/create.go.
+		sentinel, declined := payarc.ClassifyCardTokenDecline(errMsg.Message)
+
+		attrs := []any{
 			slog.String("component", "go-payarc"),
 			slog.String("op", "customers.create_token"),
 			slog.Int("status_code", res.StatusCode),
@@ -220,23 +227,20 @@ func (s *Service) createToken(input TokenInput) (*Token, error) {
 			slog.String("payarc_message", errMsg.Message),
 			slog.String("payarc_error", errMsg.Error),
 			slog.Any("payarc_field_errors", errMsg.Errors),
-		)
+		}
 
-		switch strings.ToLower(errMsg.Message) {
-		case "invalid card":
-			return nil, payarc.ErrInvalidCard
-		case "invalid cvv":
-			return nil, payarc.ErrInvalidCCV
-		case "cvv2 verification failed":
-			return nil, payarc.ErrCVV2Failed
-		case "suspected fraud":
-			return nil, payarc.ErrSuspectedFraud
-		case "do not honor":
-			return nil, payarc.ErrDoNotHonor
-		case "suspected card":
-			return nil, payarc.ErrSuspectedCard
-		case "the given data was invalid.":
-			// This error usually has more details in the "errors" field
+		if declined {
+			slog.Warn("payarc declined card token", attrs...)
+			return nil, sentinel
+		}
+
+		slog.Error("payarc token create failed", attrs...)
+
+		// "The given data was invalid." is a PayArc validation error (not a
+		// decline) — the cardholder name typically failed format checks.
+		// Surface the specific per-field message so callers can show the
+		// user what to fix.
+		if strings.EqualFold(errMsg.Message, "the given data was invalid.") {
 			if cardHolderNameErrors, ok := errMsg.Errors["card_holder_name"]; ok && len(cardHolderNameErrors) > 0 {
 				return nil, errors.New(cardHolderNameErrors[0])
 			}

--- a/customers/create_test.go
+++ b/customers/create_test.go
@@ -1,0 +1,199 @@
+package customers
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/Lendiom/go-payarc"
+	"github.com/Lendiom/go-payarc/client"
+)
+
+// levelRecorder is a slog.Handler that captures the level and message of
+// every record routed through it. It exists so tests can assert the
+// classification chose WARN vs ERROR without inspecting log output buffers.
+type levelRecorder struct {
+	records []slog.Record
+}
+
+func (lr *levelRecorder) Enabled(_ context.Context, _ slog.Level) bool { return true }
+func (lr *levelRecorder) Handle(_ context.Context, r slog.Record) error {
+	lr.records = append(lr.records, r)
+	return nil
+}
+func (lr *levelRecorder) WithAttrs([]slog.Attr) slog.Handler { return lr }
+func (lr *levelRecorder) WithGroup(string) slog.Handler      { return lr }
+
+// validTokenInput returns a TokenInput that passes the local validation
+// guards in createToken so the request actually hits the httptest server.
+func validTokenInput() TokenInput {
+	return TokenInput{
+		CardSource: payarc.CardSourceInternet,
+		CardNumber: "4111111111111111",
+		ExpMonth:   "04",
+		ExpYear:    "2029",
+		CCV:        "123",
+	}
+}
+
+func newServiceForTest(t *testing.T, statusCode int, body string) (*Service, func()) {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		_, _ = w.Write([]byte(body))
+	}))
+
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse httptest URL: %v", err)
+	}
+
+	svc := &Service{
+		client: client.Client{
+			ApiKey:     "test-key",
+			HttpClient: *srv.Client(),
+			Url:        *u,
+		},
+	}
+
+	return svc, srv.Close
+}
+
+func TestCreateToken_BusinessDeclineLogsAtWarnAndReturnsSentinel(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantErr    error
+		wantLogLvl slog.Level
+		wantLogMsg string
+	}{
+		{
+			name:       "Do Not Honor → WARN + ErrDoNotHonor",
+			statusCode: http.StatusConflict,
+			body:       `{"message":"Do not honor"}`,
+			wantErr:    payarc.ErrDoNotHonor,
+			wantLogLvl: slog.LevelWarn,
+			wantLogMsg: "payarc declined card token",
+		},
+		{
+			name:       "CVV2 Verification Failed → WARN + ErrCVV2Failed",
+			statusCode: http.StatusConflict,
+			body:       `{"message":"CVV2 verification failed"}`,
+			wantErr:    payarc.ErrCVV2Failed,
+			wantLogLvl: slog.LevelWarn,
+			wantLogMsg: "payarc declined card token",
+		},
+		{
+			name:       "Invalid Card → WARN + ErrInvalidCard",
+			statusCode: http.StatusConflict,
+			body:       `{"message":"Invalid card"}`,
+			wantErr:    payarc.ErrInvalidCard,
+			wantLogLvl: slog.LevelWarn,
+			wantLogMsg: "payarc declined card token",
+		},
+		{
+			name:       "Invalid CVV → WARN + ErrInvalidCCV",
+			statusCode: http.StatusConflict,
+			body:       `{"message":"Invalid CVV"}`,
+			wantErr:    payarc.ErrInvalidCCV,
+			wantLogLvl: slog.LevelWarn,
+			wantLogMsg: "payarc declined card token",
+		},
+		{
+			name:       "Suspected Fraud → WARN + ErrSuspectedFraud",
+			statusCode: http.StatusConflict,
+			body:       `{"message":"Suspected fraud"}`,
+			wantErr:    payarc.ErrSuspectedFraud,
+			wantLogLvl: slog.LevelWarn,
+			wantLogMsg: "payarc declined card token",
+		},
+		{
+			name:       "Suspected Card → WARN + ErrSuspectedCard",
+			statusCode: http.StatusConflict,
+			body:       `{"message":"Suspected card"}`,
+			wantErr:    payarc.ErrSuspectedCard,
+			wantLogLvl: slog.LevelWarn,
+			wantLogMsg: "payarc declined card token",
+		},
+		{
+			name:       "Validation error → ERROR (alerting path stays intact)",
+			statusCode: http.StatusUnprocessableEntity,
+			body:       `{"message":"The given data was invalid.","errors":{"card_holder_name":["The card holder name format is invalid."]}}`,
+			wantErr:    errors.New("The card holder name format is invalid."),
+			wantLogLvl: slog.LevelError,
+			wantLogMsg: "payarc token create failed",
+		},
+		{
+			name:       "Unknown message → ERROR (alerting path stays intact)",
+			statusCode: http.StatusInternalServerError,
+			body:       `{"message":"Some New Failure Mode"}`,
+			wantErr:    nil, // wrapped errors.New, not a sentinel
+			wantLogLvl: slog.LevelError,
+			wantLogMsg: "payarc token create failed",
+		},
+		{
+			name:       "Unparseable body → ERROR (the parse-failure log line)",
+			statusCode: http.StatusBadGateway,
+			body:       `<html>upstream down</html>`,
+			wantErr:    nil,
+			wantLogLvl: slog.LevelError,
+			wantLogMsg: "payarc token create failed; response body did not parse",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, cleanup := newServiceForTest(t, tt.statusCode, tt.body)
+			defer cleanup()
+
+			recorder := &levelRecorder{}
+			origLogger := slog.Default()
+			slog.SetDefault(slog.New(recorder))
+			defer slog.SetDefault(origLogger)
+
+			_, err := svc.createToken(validTokenInput())
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+
+			if tt.wantErr != nil {
+				// For the validation-error case the returned error is a fresh
+				// errors.New of the per-field message, not a sentinel, so fall
+				// back to string compare instead of errors.Is when wantErr
+				// isn't a sentinel.
+				if errors.Is(tt.wantErr, payarc.ErrInvalidCard) ||
+					errors.Is(tt.wantErr, payarc.ErrInvalidCCV) ||
+					errors.Is(tt.wantErr, payarc.ErrCVV2Failed) ||
+					errors.Is(tt.wantErr, payarc.ErrSuspectedFraud) ||
+					errors.Is(tt.wantErr, payarc.ErrDoNotHonor) ||
+					errors.Is(tt.wantErr, payarc.ErrSuspectedCard) {
+					if !errors.Is(err, tt.wantErr) {
+						t.Errorf("err = %v, want sentinel %v", err, tt.wantErr)
+					}
+				} else if err.Error() != tt.wantErr.Error() {
+					t.Errorf("err = %q, want %q", err.Error(), tt.wantErr.Error())
+				}
+			}
+
+			if len(recorder.records) != 1 {
+				t.Fatalf("expected exactly 1 log record, got %d", len(recorder.records))
+			}
+
+			rec := recorder.records[0]
+			if rec.Level != tt.wantLogLvl {
+				t.Errorf("log level = %v, want %v (msg=%q)", rec.Level, tt.wantLogLvl, rec.Message)
+			}
+
+			if rec.Message != tt.wantLogMsg {
+				t.Errorf("log message = %q, want %q", rec.Message, tt.wantLogMsg)
+			}
+		})
+	}
+}

--- a/errors.go
+++ b/errors.go
@@ -80,3 +80,41 @@ func ClassifyChargeDecline(message string) (error, bool) {
 
 	return nil, false
 }
+
+// ClassifyCardTokenDecline maps a known PayArc card-tokenization decline
+// message to its sentinel error. It returns (sentinel, true) when PayArc
+// rejected the card at tokenization for a reason the cardholder/bank owns
+// (invalid card, CVV2 failure, do-not-honor, suspected fraud, etc.) and
+// (nil, false) otherwise.
+//
+// Mirrors ClassifyChargeDecline but for the token-create code path: the set
+// of messages PayArc returns during tokenization overlaps with — but is not
+// identical to — the charge-decline set. CVV/CVV2 issues, for example, only
+// show up at token time, while "insufficient funds" only shows up at charge
+// time. Keeping them as separate classifiers keeps the WARN/ERROR decision
+// honest at each call site.
+//
+// Callers use the boolean to decide log level: known declines are expected
+// outcomes of adding a card and should be logged at WARN, while unknown
+// messages, parse failures, and server-side errors should keep ERROR-level
+// logging so they still surface in alerting dashboards.
+//
+// Matching is case-insensitive against the PayArc `message` field.
+func ClassifyCardTokenDecline(message string) (error, bool) {
+	switch strings.ToLower(message) {
+	case "invalid card":
+		return ErrInvalidCard, true
+	case "invalid cvv":
+		return ErrInvalidCCV, true
+	case "cvv2 verification failed":
+		return ErrCVV2Failed, true
+	case "suspected fraud":
+		return ErrSuspectedFraud, true
+	case "do not honor":
+		return ErrDoNotHonor, true
+	case "suspected card":
+		return ErrSuspectedCard, true
+	}
+
+	return nil, false
+}

--- a/errors.go
+++ b/errors.go
@@ -22,6 +22,13 @@ var (
 	ErrCustomerRequestedStopPayments = errors.New("customer requested stop payments for this seller")
 	ErrClosedAccount                 = errors.New("account is closed")
 	ErrReferToIssuer                 = errors.New("issuing bank declined and asked the cardholder to contact them")
+	// ErrReEnterTransaction is ISO 8583 host response code 19 (PayArc failure
+	// code D0092 — "Re-enter transaction"). The card network reported a
+	// transient processor/network glitch — the charge did NOT post, the card
+	// itself is fine, and a retry typically succeeds. Distinct sentinel so
+	// callers can surface a "try again" message and avoid disabling the
+	// payment method or auto-draft for what is effectively a network hiccup.
+	ErrReEnterTransaction = errors.New("payarc asked us to re-enter the transaction")
 )
 
 type RequestErrorErrors map[string][]string
@@ -76,6 +83,14 @@ func ClassifyChargeDecline(message string) (error, bool) {
 		// distinct host code, so keep it as its own sentinel so callers
 		// can surface a tailored "contact your card issuer" message.
 		return ErrReferToIssuer, true
+	case "re-enter transaction":
+		// ISO 8583 host response code 19 (PayArc failure code D0092). A
+		// transient processor/network glitch — the charge did NOT post,
+		// the card itself is not at fault, and a retry typically succeeds.
+		// Not strictly a "bank decline," but it IS an expected outcome of
+		// attempting a payment (not a server bug), so it belongs at WARN
+		// alongside the other declines rather than paging on-call.
+		return ErrReEnterTransaction, true
 	}
 
 	return nil, false

--- a/errors_test.go
+++ b/errors_test.go
@@ -73,6 +73,24 @@ func TestClassifyChargeDecline(t *testing.T) {
 			wantMatched: true,
 		},
 		{
+			name:        "Re-enter transaction (canonical casing)",
+			message:     "Re-enter transaction",
+			wantErr:     ErrReEnterTransaction,
+			wantMatched: true,
+		},
+		{
+			name:        "re-enter transaction (lowercase) still matches",
+			message:     "re-enter transaction",
+			wantErr:     ErrReEnterTransaction,
+			wantMatched: true,
+		},
+		{
+			name:        "RE-ENTER TRANSACTION (uppercase) still matches",
+			message:     "RE-ENTER TRANSACTION",
+			wantErr:     ErrReEnterTransaction,
+			wantMatched: true,
+		},
+		{
 			name:        "Unknown message does not match (must stay at ERROR)",
 			message:     "Some new failure mode PayArc invented",
 			wantErr:     nil,

--- a/errors_test.go
+++ b/errors_test.go
@@ -100,3 +100,93 @@ func TestClassifyChargeDecline(t *testing.T) {
 		})
 	}
 }
+
+func TestClassifyCardTokenDecline(t *testing.T) {
+	tests := []struct {
+		name        string
+		message     string
+		wantErr     error
+		wantMatched bool
+	}{
+		{
+			name:        "Invalid Card",
+			message:     "Invalid Card",
+			wantErr:     ErrInvalidCard,
+			wantMatched: true,
+		},
+		{
+			name:        "Invalid CVV",
+			message:     "Invalid CVV",
+			wantErr:     ErrInvalidCCV,
+			wantMatched: true,
+		},
+		{
+			name:        "CVV2 Verification Failed (canonical casing)",
+			message:     "CVV2 Verification Failed",
+			wantErr:     ErrCVV2Failed,
+			wantMatched: true,
+		},
+		{
+			name:        "cvv2 verification failed (lowercase) still matches",
+			message:     "cvv2 verification failed",
+			wantErr:     ErrCVV2Failed,
+			wantMatched: true,
+		},
+		{
+			name:        "Suspected Fraud",
+			message:     "Suspected Fraud",
+			wantErr:     ErrSuspectedFraud,
+			wantMatched: true,
+		},
+		{
+			name:        "Do Not Honor",
+			message:     "Do Not Honor",
+			wantErr:     ErrDoNotHonor,
+			wantMatched: true,
+		},
+		{
+			name:        "Suspected Card",
+			message:     "Suspected Card",
+			wantErr:     ErrSuspectedCard,
+			wantMatched: true,
+		},
+		{
+			name:        "Charge-only message does not match (Insufficient Funds is not a token decline)",
+			message:     "Insufficient Funds",
+			wantErr:     nil,
+			wantMatched: false,
+		},
+		{
+			name:        "Validation error is not a decline (the given data was invalid.)",
+			message:     "The given data was invalid.",
+			wantErr:     nil,
+			wantMatched: false,
+		},
+		{
+			name:        "Unknown message does not match (must stay at ERROR)",
+			message:     "Some new failure mode PayArc invented",
+			wantErr:     nil,
+			wantMatched: false,
+		},
+		{
+			name:        "Empty message does not match",
+			message:     "",
+			wantErr:     nil,
+			wantMatched: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotErr, gotMatched := ClassifyCardTokenDecline(tt.message)
+
+			if gotMatched != tt.wantMatched {
+				t.Errorf("matched = %v, want %v", gotMatched, tt.wantMatched)
+			}
+
+			if !errors.Is(gotErr, tt.wantErr) {
+				t.Errorf("err = %v, want %v", gotErr, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Two related Grafana-review fixes — same WARN/ERROR split, two different call sites.

## 1. `customers/createToken` should log known declines at WARN (commit 1)
PR #18 split charge declines into WARN vs ERROR so the alerting path only fires on genuinely unexpected failures. The same fix was never extended to `customers/createToken`, which still logs at ERROR for every PayArc response — including known business declines like "Do not honor" and "CVV2 verification failed" that the function already maps to typed sentinels.

- Add `ClassifyCardTokenDecline` in `errors.go` for the token-specific set: `invalid card`, `invalid cvv`, `cvv2 verification failed`, `suspected fraud`, `do not honor`, `suspected card`. Kept as a separate classifier from `ClassifyChargeDecline` because the message sets only partially overlap (CVV/CVV2 are token-only, "insufficient funds" is charge-only) — keeping them separate keeps the WARN/ERROR decision honest at each call site.
- Refactor `createToken` to use the `(sentinel, declined)` split, mirroring `charges/create.go`. Declines log at WARN with `"payarc declined card token"` and return the sentinel directly. Unknown messages stay at ERROR. The `"the given data was invalid."` per-field extraction path is preserved verbatim — it's a validation error, not a decline.

## 2. `ClassifyChargeDecline` should match "Re-enter transaction" (commit 2)
PayArc failure code D0092 / ISO 8583 host response code 19. A transient processor/network glitch — the charge did NOT post, the card itself is not at fault, and a retry typically succeeds. Not strictly a "bank decline" but it IS an expected outcome of attempting a payment, so it belongs at WARN alongside the other declines.

- Add `ErrReEnterTransaction` sentinel and the `"re-enter transaction"` case to `ClassifyChargeDecline`. Charges/Create now logs at WARN and returns the sentinel, so callers can `errors.Is(err, payarc.ErrReEnterTransaction)` instead of string-matching the wrapped message.

## Why
Spotted while reviewing lendiom-production lendiom-api Grafana logs:
- The only ERROR-level `payarc token create failed` entries in the past 24h were for `Do not honor` and `CVV2 verification failed` — exactly the cases commit 1 moves to WARN.
- One ERROR-level `payarc charge create failed` for `Re-enter transaction` fell into the downstream `unhandled_processor_error` alert path even though it's the textbook transient-retry case — commit 2 reclassifies it.

## Test plan
- [x] `go test ./...` green across all packages
- [x] `TestClassifyChargeDecline` covers Re-enter transaction in canonical, lowercase, and uppercase casings (+ existing negatives)
- [x] `TestClassifyCardTokenDecline` (new) covers the 6 declined cases + charge-only / validation / unknown / empty negatives
- [x] `TestCreate_BusinessDeclineLogsAtWarnAndReturnsSentinel` (charges) extended with a `Re-enter transaction → WARN + ErrReEnterTransaction` case
- [x] `TestCreateToken_BusinessDeclineLogsAtWarnAndReturnsSentinel` (new, customers) mirrors `charges/create_test.go`: stands up an httptest server, captures slog records, asserts WARN+sentinel for each known decline and ERROR for unknown/validation/unparseable bodies
- [ ] Tag a release (v0.9.12 or similar) and bump `landpro-server` go.mod; follow-up to landpro-server PR #757 can then switch its `strings.Contains("Re-enter transaction")` branch to `errors.Is(err, payarc.ErrReEnterTransaction)`