### PR TITLE
feat(charges): include transaction_metadata in GetByID

### DIFF
--- a/charges/get.go
+++ b/charges/get.go
@@ -34,7 +34,10 @@ func (s *Service) GetAll(limit, page uint) (int, []payarc.Charge, error) {
 }
 
 func (s *Service) GetByID(id string) (*payarc.Charge, error) {
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/%s", s.client.Url.String(), id), nil)
+	// Request transaction_metadata explicitly: it is an optional include that the
+	// detail endpoint omits by default (mirrors GetAll). Default includes such as
+	// the card relation are additive and remain present.
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/%s?include=transaction_metadata", s.client.Url.String(), id), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/charges/get_test.go
+++ b/charges/get_test.go
@@ -1,0 +1,69 @@
+package charges
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/Lendiom/go-payarc/client"
+)
+
+// TestGetByID_RequestsTransactionMetadata verifies the detail endpoint is called
+// with include=transaction_metadata and that the returned charge's metadata is
+// parsed. PayArc omits transaction_metadata from the charge detail response
+// unless it is explicitly included.
+func TestGetByID_RequestsTransactionMetadata(t *testing.T) {
+	const body = `{"data":{"object":"Charge","id":"chg_abc123","amount":35022,"status":"settled","captured":1,"transaction_metadata":{"data":[{"object":"ChargeTransactionMetadata","key":"loanId","value":"640747b60796a70001820d43"}]}}}`
+
+	var gotPath, gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.Query().Get("include")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse httptest URL: %v", err)
+	}
+
+	svc := &Service{
+		client: client.Client{
+			ApiKey:     "test-key",
+			HttpClient: *srv.Client(),
+			Url:        *u,
+		},
+	}
+
+	charge, err := svc.GetByID("chg_abc123")
+	if err != nil {
+		t.Fatalf("GetByID returned error: %v", err)
+	}
+
+	if gotPath != "/chg_abc123" {
+		t.Errorf("request path = %q, want %q", gotPath, "/chg_abc123")
+	}
+
+	if gotQuery != "transaction_metadata" {
+		t.Errorf("include query = %q, want %q", gotQuery, "transaction_metadata")
+	}
+
+	if charge.TransactionMetadata == nil {
+		t.Fatal("expected transaction_metadata to be parsed, got nil")
+	}
+
+	var loanID string
+	for _, m := range charge.TransactionMetadata.Data {
+		if m.Key == "loanId" {
+			loanID = m.Value
+		}
+	}
+
+	if loanID != "640747b60796a70001820d43" {
+		t.Errorf("metadata loanId = %q, want %q", loanID, "640747b60796a70001820d43")
+	}
+}


### PR DESCRIPTION
## Why
The charge **detail** endpoint (`GetByID`) omits `transaction_metadata` unless it's explicitly included — only `GetAll` requested it. Callers that need the metadata Lendiom attaches at charge creation (`loanId`, `orgId`, `p`, `f`) received a nil `TransactionMetadata` from `GetByID`.

This blocked landpro-server's PayArc orphaned-charge recovery from authoritatively binding a fetched charge to its loan (it had to be reverted — see FideTech/landpro-server#775).

## What
`GetByID` now requests `?include=transaction_metadata`, mirroring `GetAll`. PayArc's `include` is additive, so default includes (e.g. the `card` relation) remain present — existing `GetByID` consumers that read `charge.Card.Data` are unaffected.

## Test
Added `charges/get_test.go` asserting the request carries `include=transaction_metadata` and that the returned charge's metadata is parsed. `go build/vet/test ./...` pass.

## Follow-up
After release (suggest `v0.9.13`), bump `landpro-server` and re-introduce the loan-id binding that was reverted in #775.