### PR TITLE
feat(webhooks): add tolerant WebhookCharge type for charge events

### DIFF
--- a/webhook_charge.go
+++ b/webhook_charge.go
@@ -1,0 +1,61 @@
+package payarc
+
+// WebhookCharge is the charge shape PayArc delivers inside a charge webhook's
+// api_response ("original.data"). It intentionally differs from Charge:
+//
+//   - PayArc encodes some fields as JSON strings in webhooks (e.g. "captured":"1",
+//     "amount_approved":"39646") that are numbers/booleans in the charge detail and
+//     list API responses. Unmarshalling a webhook payload into Charge therefore
+//     fails, so this is a separate, tolerant type.
+//   - The webhook payload does NOT include transaction_metadata (it is only listed
+//     under meta.include as an available relation). The loan/payment metadata
+//     Lendiom attaches lives in the event's request_payload, or can be fetched
+//     authoritatively via charges.GetByID (which requests include=transaction_metadata).
+//
+// Only the stable fields a consumer needs to identify and route a charge are
+// modeled; authoritative amounts and metadata should come from charges.GetByID.
+type WebhookCharge struct {
+	ID          string       `json:"id"`
+	Type        string       `json:"type"`
+	Amount      int          `json:"amount"`
+	AuthCode    string       `json:"auth_code"`
+	FailureCode string       `json:"failure_code"`
+	Status      ChargeStatus `json:"status"`
+	// Captured is a string ("1"/"0") in webhook payloads. Use IsCaptured for a bool.
+	Captured  string            `json:"captured"`
+	CreatedAt int64             `json:"created_at"`
+	Card      WebhookChargeCard `json:"card"`
+}
+
+// IsCaptured reports whether the webhook charge was captured.
+func (c WebhookCharge) IsCaptured() bool {
+	return c.Captured == "1"
+}
+
+// IsCard reports whether the charge was paid with a card (vs ACH). PayArc only
+// delivers charge webhooks for card charges; ACH is not sent as a charge event.
+func (c WebhookCharge) IsCard() bool {
+	return c.Card.Data.ID != ""
+}
+
+// WebhookChargeCard wraps the card relation on a webhook charge.
+type WebhookChargeCard struct {
+	Data WebhookChargeCardData `json:"data"`
+}
+
+// WebhookChargeCardData holds the card fields exposed on a webhook charge.
+type WebhookChargeCardData struct {
+	ID string `json:"id"`
+}
+
+// WebhookChargeResponse models the api_response payload of a PayArc charge webhook
+// event (WebhookEvent.ApiResponse), e.g. "Charges Created".
+type WebhookChargeResponse struct {
+	Headers  map[string]string   `json:"headers"`
+	Original WebhookChargeResult `json:"original"`
+}
+
+// WebhookChargeResult is the "original" envelope wrapping the charge data.
+type WebhookChargeResult struct {
+	Data WebhookCharge `json:"data"`
+}

--- a/webhook_charge_test.go
+++ b/webhook_charge_test.go
@@ -1,0 +1,84 @@
+package payarc
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// realWebhookApiResponse is a trimmed but faithful copy of a real PayArc
+// "Charges Created" api_response. Note "captured" and "amount_approved" are JSON
+// strings (not numbers), and there is no transaction_metadata under data.
+const realWebhookApiResponse = `{
+  "headers": {},
+  "original": {
+    "data": {
+      "object": "Charge",
+      "id": "nDXOXWWnRnbBbObL",
+      "amount": 39646,
+      "amount_approved": "39646",
+      "amount_refunded": 0,
+      "type": "Sale",
+      "captured": "1",
+      "is_refunded": 0,
+      "status": "submitted_for_settlement",
+      "auth_code": "202054",
+      "failure_code": null,
+      "created_at": 1782270224,
+      "card": {"data": {"object": "Card", "id": "19v20vP2N9M1L0M5", "last4digit": "5834"}},
+      "splits": {"data": []}
+    },
+    "meta": {"include": ["review", "transaction_metadata", "splits"]}
+  },
+  "exception": null
+}`
+
+func TestWebhookChargeResponse_ParsesRealPayload(t *testing.T) {
+	var resp WebhookChargeResponse
+	if err := json.Unmarshal([]byte(realWebhookApiResponse), &resp); err != nil {
+		t.Fatalf("failed to unmarshal real webhook api_response: %v", err)
+	}
+
+	charge := resp.Original.Data
+
+	if charge.ID != "nDXOXWWnRnbBbObL" {
+		t.Errorf("id = %q, want %q", charge.ID, "nDXOXWWnRnbBbObL")
+	}
+
+	if !charge.IsCaptured() {
+		t.Errorf("IsCaptured() = false, want true (captured=%q)", charge.Captured)
+	}
+
+	if !charge.IsCard() {
+		t.Error("IsCard() = false, want true")
+	}
+
+	if charge.Card.Data.ID != "19v20vP2N9M1L0M5" {
+		t.Errorf("card.data.id = %q, want %q", charge.Card.Data.ID, "19v20vP2N9M1L0M5")
+	}
+
+	if charge.AuthCode != "202054" {
+		t.Errorf("auth_code = %q, want %q", charge.AuthCode, "202054")
+	}
+
+	if charge.FailureCode != "" {
+		t.Errorf("failure_code = %q, want empty", charge.FailureCode)
+	}
+
+	if charge.CreatedAt != 1782270224 {
+		t.Errorf("created_at = %d, want %d", charge.CreatedAt, 1782270224)
+	}
+
+	if charge.Status != ChargeStatus("submitted_for_settlement") {
+		t.Errorf("status = %q, want submitted_for_settlement", charge.Status)
+	}
+}
+
+// TestCharge_FailsOnWebhookStrings documents WHY WebhookCharge exists: the
+// API-shaped Charge cannot unmarshal a webhook payload because captured/amount_approved
+// arrive as strings.
+func TestCharge_FailsOnWebhookStrings(t *testing.T) {
+	var resp WebhookEventChargeResponse
+	if err := json.Unmarshal([]byte(realWebhookApiResponse), &resp); err == nil {
+		t.Fatal("expected Charge unmarshal to fail on string-encoded captured/amount_approved, but it succeeded")
+	}
+}


### PR DESCRIPTION
## Why
The charge webhook `api_response` encodes some fields as JSON **strings** (`"captured":"1"`, `"amount_approved":"39646"`) that are numbers/booleans in the charge detail/list API, so unmarshalling a webhook payload into `Charge` **fails**. It also does **not** include `transaction_metadata` under `data` (only in `meta.include`); that metadata is in the event's `request_payload` or must be fetched via `charges.GetByID`.

landpro-server had to hand-roll a tolerant struct in its webhook handler; this moves that definition into the library where it belongs.

## What
- `WebhookCharge` / `WebhookChargeResponse` modeling the webhook's actual shape, with `IsCaptured()` / `IsCard()` helpers.
- Tests parse a real `Charges Created` payload, and assert the existing `Charge` (`WebhookEventChargeResponse`) **fails** on the same payload (documents why this type exists).

Verified the shape against real production webhook payloads in Grafana/Loki.

## Follow-up
Bump landpro-server and replace its local tolerant struct with `payarc.WebhookChargeResponse`; also fix landpro to source loanId/p/f from `GetByID` (authoritative) since the webhook body carries no `transaction_metadata`.
