### PR TITLE
fix(errors): classify "Expired Card" as a known token-time decline

### DIFF
--- a/customers/create_test.go
+++ b/customers/create_test.go
@@ -123,6 +123,14 @@ func TestCreateToken_BusinessDeclineLogsAtWarnAndReturnsSentinel(t *testing.T) {
 			wantLogMsg: "payarc declined card token",
 		},
 		{
+			name:       "Expired Card → WARN + ErrExpiredCard",
+			statusCode: http.StatusConflict,
+			body:       `{"message":"Expired Card"}`,
+			wantErr:    payarc.ErrExpiredCard,
+			wantLogLvl: slog.LevelWarn,
+			wantLogMsg: "payarc declined card token",
+		},
+		{
 			name:       "Validation error → ERROR (alerting path stays intact)",
 			statusCode: http.StatusUnprocessableEntity,
 			body:       `{"message":"The given data was invalid.","errors":{"card_holder_name":["The card holder name format is invalid."]}}`,
@@ -173,7 +181,8 @@ func TestCreateToken_BusinessDeclineLogsAtWarnAndReturnsSentinel(t *testing.T) {
 					errors.Is(tt.wantErr, payarc.ErrCVV2Failed) ||
 					errors.Is(tt.wantErr, payarc.ErrSuspectedFraud) ||
 					errors.Is(tt.wantErr, payarc.ErrDoNotHonor) ||
-					errors.Is(tt.wantErr, payarc.ErrSuspectedCard) {
+					errors.Is(tt.wantErr, payarc.ErrSuspectedCard) ||
+					errors.Is(tt.wantErr, payarc.ErrExpiredCard) {
 					if !errors.Is(err, tt.wantErr) {
 						t.Errorf("err = %v, want sentinel %v", err, tt.wantErr)
 					}

--- a/errors.go
+++ b/errors.go
@@ -129,6 +129,14 @@ func ClassifyCardTokenDecline(message string) (error, bool) {
 		return ErrDoNotHonor, true
 	case "suspected card":
 		return ErrSuspectedCard, true
+	case "expired card":
+		// PayArc returns "Expired Card" (HTTP 409) from the token-create
+		// endpoint when callers pass AuthorizeCard=true and the $0 auth is
+		// declined because the card's expiration date has passed. It's a
+		// cardholder-owned condition — the customer needs to use a
+		// different card — not a server bug, so it belongs at WARN
+		// alongside the other known token declines.
+		return ErrExpiredCard, true
 	}
 
 	return nil, false

--- a/errors_test.go
+++ b/errors_test.go
@@ -169,6 +169,18 @@ func TestClassifyCardTokenDecline(t *testing.T) {
 			wantMatched: true,
 		},
 		{
+			name:        "Expired Card (canonical casing)",
+			message:     "Expired Card",
+			wantErr:     ErrExpiredCard,
+			wantMatched: true,
+		},
+		{
+			name:        "expired card (lowercase) still matches",
+			message:     "expired card",
+			wantErr:     ErrExpiredCard,
+			wantMatched: true,
+		},
+		{
 			name:        "Charge-only message does not match (Insufficient Funds is not a token decline)",
 			message:     "Insufficient Funds",
 			wantErr:     nil,


### PR DESCRIPTION
## Summary

- Add `"expired card"` to `ClassifyCardTokenDecline` so token-create responses with an expired card return `ErrExpiredCard` (sentinel) and log at WARN instead of ERROR.
- Extend `TestClassifyCardTokenDecline` and `TestCreateToken_BusinessDeclineLogsAtWarnAndReturnsSentinel` to cover the new case end-to-end.

## Why

PayArc's token-create endpoint (used with `AuthorizeCard=true`) runs a $0 auth and can return `HTTP 409 {"message":"Expired Card"}` when the card's expiration date has passed. That's a cardholder-owned condition — same as the other known declines — but until this change `ClassifyCardTokenDecline` did not recognize the message, so:

- `customers/create.go:237` logged the response at ERROR, paging on-call for a benign user event, and
- the returned error was `errors.New("Expired Card")` instead of the typed `ErrExpiredCard` sentinel, so downstream callers had to string-match to give the user a helpful message.

Spotted in production (`lendiom-api` in `lendiom-production`) as the only ERROR-level log across a 24-hour window — a client-portal user tried to add an expired card and got the generic "check card details or contact your bank" message.

The charge classifier already handles `"expired card"` at [`errors.go:71`](../blob/master/errors.go#L71); this change mirrors that case in the token classifier. The two classifiers stay separate on purpose (the message sets overlap but don't match — `Insufficient Funds` is charge-only, `CVV2 Verification Failed` is token-only, etc.).

## Test plan

- [x] `go test ./...` — all packages green.
- [x] `TestClassifyCardTokenDecline` covers canonical (`"Expired Card"`) and lowercase (`"expired card"`) inputs, asserting `(ErrExpiredCard, true)`.
- [x] `TestCreateToken_BusinessDeclineLogsAtWarnAndReturnsSentinel` sends `HTTP 409 {"message":"Expired Card"}` through `createToken` and asserts a single `slog.LevelWarn` record with message `"payarc declined card token"` and returned error `ErrExpiredCard`.

## Follow-up (separate change, `landpro-server`)

Once this ships and the dep is bumped, `core/paymentprocessors/payarc.go` `CreateCardPaymentMethod` should add an `errors.Is(err, payarc.ErrExpiredCard)` branch returning "Your card is expired. Please use a different card." — currently the expired-card fall-through hits the `unhandled_processor_error` catch-all with the generic message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)